### PR TITLE
Add aggregator

### DIFF
--- a/v5/pivotal/aggregator.go
+++ b/v5/pivotal/aggregator.go
@@ -133,16 +133,21 @@ func (a *Aggregation) Send() (*Aggregation, error) {
 	for currentPage := 1; currentPage <= max; currentPage++ {
 		currentReqs := paginate(a.requests, currentPage, N, perPage)
 
-		a.aggregatedResponse = make(map[string]interface{})
+		aggregatedResponse := make(map[string]interface{})
 
 		req, err := a.service.client.NewRequest("POST", aggregatorURL, currentReqs)
 		if err != nil {
 			return nil, err
 		}
 
-		_, err = a.service.client.Do(req, &a.aggregatedResponse)
+		_, err = a.service.client.Do(req, &aggregatedResponse)
 		if err != nil {
 			return nil, err
+		}
+
+		// Appending the response body into the current aggregation for getters.
+		for url, response := range aggregatedResponse {
+			a.aggregatedResponse[url] = response
 		}
 	}
 

--- a/v5/pivotal/aggregator.go
+++ b/v5/pivotal/aggregator.go
@@ -8,126 +8,191 @@ import (
 
 const aggregatorURL = "https://www.pivotaltracker.com/services/v5/aggregator"
 
+// AggregatorService is used to wrap the client.
 type AggregatorService struct {
-	client             *Client
-	requests           []string
-	aggregatedResponse map[string]interface{} // Storing the response temporarily.
+	client *Client
+}
+
+// Aggregation object stores the state of the aggregation.
+type Aggregation struct {
+	// Requests are the GET requests that are used by the aggregator.
+	requests []string
+
+	// Storing the response json along with the urls.
+	aggregatedResponse map[string]interface{}
+
+	// Map for quickly accessing the stories using their IDs
+	aggregatedData map[int]*AggregatedStory
+}
+
+// AggregatedStory contains the story, comment and review information.
+type AggregatedStory struct {
+	Story    *Story
+	Comments *[]Comment
+	Reviews  *[]Review
 }
 
 func newAggregatorService(client *Client) *AggregatorService {
-	return &AggregatorService{client, []string{}, nil}
+	return &AggregatorService{client}
 }
 
-// For making sure the request is in empty state
-func (service *AggregatorService) InitRequest() {
-	service.client.Aggregator.requests = []string{}
-	service.client.Aggregator.aggregatedResponse = make(map[string]interface{})
+func (a *Aggregation) maybeCreateAggregatedStory(StoryID int) *AggregatedStory {
+	story, ok := a.aggregatedData[StoryID]
+	if !ok {
+		a.aggregatedData[StoryID] = &AggregatedStory{}
+		return a.aggregatedData[StoryID]
+	}
+	return story
 }
 
-func (service *AggregatorService) QueueStoryCommentsByID(projectID, storyID int) {
+// Fills the urls for the aggregator and sends the request to PT.
+func (service *AggregatorService) fillAggregationData(ProjectID int, StoryIDs []int) (*Aggregation, error) {
+	aggregation := &Aggregation{
+		aggregatedResponse: make(map[string]interface{}),
+		aggregatedData:     make(map[int]*AggregatedStory),
+	}
+	for _, ID := range StoryIDs {
+		aggregation.queueStoryByID(ProjectID, ID)
+		aggregation.queueStoryCommentsByID(ProjectID, ID)
+		aggregation.queueReviewsByID(ProjectID, ID)
+	}
+	err := service.sendAggregationRequest(aggregation)
+	if err != nil {
+		return nil, err
+	}
+	return aggregation, nil
+}
+
+// Converts the JSON response from PT into the related structs(Story, Comment, Review).
+func (service *AggregatorService) processAggregationMaps(aggregation *Aggregation) (*Aggregation, error) {
+	// Creating the map with the story information.
+	for url, byteStory := range aggregation.aggregatedResponse {
+		byteData, _ := json.Marshal(byteStory)
+
+		if strings.Contains(url, "reviews") {
+			var reviews []Review
+			err := json.Unmarshal(byteData, &reviews)
+			if err != nil {
+				return nil, err
+			}
+			if len(reviews) == 0 {
+				continue
+			}
+			// Accessing the reviews using the story ID
+			storyData := aggregation.maybeCreateAggregatedStory(reviews[0].StoryID)
+			storyData.Reviews = &reviews
+			continue
+		}
+
+		if strings.Contains(url, "comments") {
+			var comments []Comment
+			err := json.Unmarshal(byteData, &comments)
+			if err != nil {
+				return nil, err
+			}
+			if len(comments) == 0 {
+				continue
+			}
+			// Accessing the reviews using the story ID
+			storyData := aggregation.maybeCreateAggregatedStory(comments[0].StoryID)
+			storyData.Comments = &comments
+			continue
+		}
+
+		// Handling get story requests if it isn't comments/reviews.
+		var story Story
+		err := json.Unmarshal(byteData, &story)
+		if err != nil {
+			return nil, err
+		}
+		if story.ID == 0 {
+			continue
+		}
+		// Accessing the story with the story ID
+		storyData := aggregation.maybeCreateAggregatedStory(story.ID)
+		storyData.Story = &story
+
+	}
+
+	return aggregation, nil
+}
+
+// BuildStoriesCommentsAndReviewsFor returns the reviews, comments and the story information
+// for the given project and story IDs.
+func (service *AggregatorService) BuildStoriesCommentsAndReviewsFor(ProjectID int, StoryIDs []int) (*Aggregation, error) {
+	if len(StoryIDs) > 5 {
+		// Aggregator doesn't seem to be returning more than 15 requests in total.
+		return nil, fmt.Errorf("There can be a maximum number of 5 Story IDs.")
+	}
+
+	aggregation, err := service.fillAggregationData(ProjectID, StoryIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	aggregation, err = service.processAggregationMaps(aggregation)
+	if err != nil {
+		return nil, err
+	}
+
+	return aggregation, nil
+}
+
+// Adds the url for the comments to the aggregation data.
+func (a *Aggregation) queueStoryCommentsByID(projectID, storyID int) {
 	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d/comments", projectID, storyID)
-	service.requests = append(service.requests, u)
+	a.requests = append(a.requests, u)
 }
 
-func (service *AggregatorService) QueueStoryByID(projectID, storyID int) {
+// Adds the url for the story to the aggregation data.
+func (a *Aggregation) queueStoryByID(projectID, storyID int) {
 	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d", projectID, storyID)
-	service.requests = append(service.requests, u)
+	a.requests = append(a.requests, u)
 }
 
-func (service *AggregatorService) QueueReviewsByID(projectID, storyID int) {
+// Adds the url for the reviews to the aggregation data.
+func (a *Aggregation) queueReviewsByID(projectID, storyID int) {
 	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d/reviews?fields=id,story_id,review_type,review_type_id,reviewer_id,status,created_at,updated_at,kind", projectID, storyID)
-	service.requests = append(service.requests, u)
+	a.requests = append(a.requests, u)
 }
 
-func (service *AggregatorService) FinishRequest() error {
-	req, err := service.client.NewRequest("POST", aggregatorURL, service.requests)
+// Sends the request for the aggregation.
+func (service *AggregatorService) sendAggregationRequest(a *Aggregation) error {
+	req, err := service.client.NewRequest("POST", aggregatorURL, a.requests)
 	if err != nil {
 		return err
 	}
 
-	_, err = service.client.Do(req, &service.aggregatedResponse)
+	_, err = service.client.Do(req, &a.aggregatedResponse)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (service *AggregatorService) GetStoryReviewsFromRequest() (map[int][]Review, error) {
-	// For storing the comments using story IDs directly
-	reviewsMap := make(map[int][]Review)
-
-	for url, byteStory := range service.aggregatedResponse {
-		// Skip the requests that are not comments
-		if !strings.Contains(url, "reviews") {
-			continue
-		}
-		byteData, _ := json.Marshal(byteStory)
-
-		var reviews []Review
-		err := json.Unmarshal(byteData, &reviews)
-		if err != nil {
-			return nil, err
-		}
-		if len(reviews) == 0 {
-			break
-		}
-
-		// Updating the commentsMap using the StoryID
-		reviewsMap[reviews[0].StoryID] = reviews
+// Returns the story using StoryID from the aggregation.
+func (a *Aggregation) GetStory(storyID int) (*Story, error) {
+	story, ok := a.aggregatedData[storyID]
+	if !ok {
+		return nil, fmt.Errorf("Story %d doesn't exist.", storyID)
 	}
-	return reviewsMap, nil
-
+	return story.Story, nil
 }
 
-func (service *AggregatorService) GetStoryCommentsFromRequest() (map[int][]Comment, error) {
-	// For storing the comments using story IDs directly
-	commentsMap := make(map[int][]Comment)
-
-	for url, byteStory := range service.aggregatedResponse {
-		// Skip the requests that are not comments
-		if !strings.Contains(url, "comments") {
-			continue
-		}
-		byteData, _ := json.Marshal(byteStory)
-
-		var comments []Comment
-		err := json.Unmarshal(byteData, &comments)
-		if err != nil {
-			return nil, err
-		}
-		if len(comments) == 0 {
-			break
-		}
-
-		// Updating the commentsMap using the StoryID
-		commentsMap[comments[0].StoryID] = comments
+// Returns the comments using story id from the aggregation.
+func (a *Aggregation) GetComments(storyID int) ([]Comment, error) {
+	story, ok := a.aggregatedData[storyID]
+	if !ok {
+		return nil, fmt.Errorf("Story %d doesn't exist.", storyID)
 	}
-	return commentsMap, nil
-
+	return *story.Comments, nil
 }
 
-func (service *AggregatorService) GetStoriesFromRequest() (map[int]Story, error) {
-	// For storing the stories using IDs directly
-	storyIDMap := make(map[int]Story)
-
-	for url, byteStory := range service.aggregatedResponse {
-		// Skip the requests that are not labels.
-		if !strings.Contains(url, "stories") {
-			continue
-		}
-		byteData, err := json.Marshal(byteStory)
-		if err != nil {
-			return nil, err
-		}
-
-		var story Story
-		err = json.Unmarshal(byteData, &story)
-		if err != nil {
-			return nil, err
-		}
-
-		storyIDMap[story.ID] = story
+// Returns the reviews using the story id from the aggregation.
+func (a *Aggregation) GetReviews(storyID int) ([]Review, error) {
+	story, ok := a.aggregatedData[storyID]
+	if !ok {
+		return nil, fmt.Errorf("Story %d doesn't exist.", storyID)
 	}
-	return storyIDMap, nil
-
+	return *story.Reviews, nil
 }

--- a/v5/pivotal/aggregator.go
+++ b/v5/pivotal/aggregator.go
@@ -1,0 +1,133 @@
+package pivotal
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const aggregatorURL = "https://www.pivotaltracker.com/services/v5/aggregator"
+
+type AggregatorService struct {
+	client             *Client
+	requests           []string
+	aggregatedResponse map[string]interface{} // Storing the response temporarily.
+}
+
+func newAggregatorService(client *Client) *AggregatorService {
+	return &AggregatorService{client, []string{}, nil}
+}
+
+// For making sure the request is in empty state
+func (service *AggregatorService) InitRequest() {
+	service.client.Aggregator.requests = []string{}
+	service.client.Aggregator.aggregatedResponse = make(map[string]interface{})
+}
+
+func (service *AggregatorService) QueueStoryCommentsByID(projectID, storyID int) {
+	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d/comments", projectID, storyID)
+	service.requests = append(service.requests, u)
+}
+
+func (service *AggregatorService) QueueStoryByID(projectID, storyID int) {
+	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d", projectID, storyID)
+	service.requests = append(service.requests, u)
+}
+
+func (service *AggregatorService) QueueReviewsByID(projectID, storyID int) {
+	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d/reviews?fields=id,story_id,review_type,review_type_id,reviewer_id,status,created_at,updated_at,kind", projectID, storyID)
+	service.requests = append(service.requests, u)
+}
+
+func (service *AggregatorService) FinishRequest() error {
+	req, err := service.client.NewRequest("POST", aggregatorURL, service.requests)
+	if err != nil {
+		return err
+	}
+
+	_, err = service.client.Do(req, &service.aggregatedResponse)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (service *AggregatorService) GetStoryReviewsFromRequest() (map[int][]Review, error) {
+	// For storing the comments using story IDs directly
+	reviewsMap := make(map[int][]Review)
+
+	for url, byteStory := range service.aggregatedResponse {
+		// Skip the requests that are not comments
+		if !strings.Contains(url, "reviews") {
+			continue
+		}
+		byteData, _ := json.Marshal(byteStory)
+
+		var reviews []Review
+		err := json.Unmarshal(byteData, &reviews)
+		if err != nil {
+			return nil, err
+		}
+		if len(reviews) == 0 {
+			break
+		}
+
+		// Updating the commentsMap using the StoryID
+		reviewsMap[reviews[0].StoryID] = reviews
+	}
+	return reviewsMap, nil
+
+}
+
+func (service *AggregatorService) GetStoryCommentsFromRequest() (map[int][]Comment, error) {
+	// For storing the comments using story IDs directly
+	commentsMap := make(map[int][]Comment)
+
+	for url, byteStory := range service.aggregatedResponse {
+		// Skip the requests that are not comments
+		if !strings.Contains(url, "comments") {
+			continue
+		}
+		byteData, _ := json.Marshal(byteStory)
+
+		var comments []Comment
+		err := json.Unmarshal(byteData, &comments)
+		if err != nil {
+			return nil, err
+		}
+		if len(comments) == 0 {
+			break
+		}
+
+		// Updating the commentsMap using the StoryID
+		commentsMap[comments[0].StoryID] = comments
+	}
+	return commentsMap, nil
+
+}
+
+func (service *AggregatorService) GetStoriesFromRequest() (map[int]Story, error) {
+	// For storing the stories using IDs directly
+	storyIDMap := make(map[int]Story)
+
+	for url, byteStory := range service.aggregatedResponse {
+		// Skip the requests that are not labels.
+		if !strings.Contains(url, "stories") {
+			continue
+		}
+		byteData, err := json.Marshal(byteStory)
+		if err != nil {
+			return nil, err
+		}
+
+		var story Story
+		err = json.Unmarshal(byteData, &story)
+		if err != nil {
+			return nil, err
+		}
+
+		storyIDMap[story.ID] = story
+	}
+	return storyIDMap, nil
+
+}

--- a/v5/pivotal/aggregator.go
+++ b/v5/pivotal/aggregator.go
@@ -54,6 +54,11 @@ func (a *Aggregation) Story(projectID, storyID int) *Aggregation {
 	return a
 }
 
+func (a *Aggregation) StoryUsingStoryID(storyID int) *Aggregation {
+	a.requests = append(a.requests, BuildStoryURLOnlyUsingStoryID(storyID))
+	return a
+}
+
 // Stories adds the urls for the slice of story IDs.
 func (a *Aggregation) Stories(projectID int, storyIDs []int) *Aggregation {
 	for _, storyID := range storyIDs {
@@ -87,6 +92,10 @@ func (a *Aggregation) ReviewsOfStories(projectID int, storyIDs []int) *Aggregati
 		a.ReviewsOfStory(projectID, storyID)
 	}
 	return a
+}
+
+func BuildStoryURLOnlyUsingStoryID(storyID int) string {
+	return fmt.Sprintf("/services/v5/stories/%d", storyID)
 }
 
 func BuildStoryURL(projectID, storyID int) string {
@@ -138,6 +147,24 @@ func (a *Aggregation) Send() (*Aggregation, error) {
 	}
 
 	return a, nil
+}
+
+// Returns the story using StoryID from the aggregation.
+func (a *Aggregation) GetStoryOnlyUsingStoryID(storyID int) (*Story, error) {
+	u := BuildStoryURLOnlyUsingStoryID(storyID)
+	response, ok := a.aggregatedResponse[u]
+	if !ok {
+		return nil, fmt.Errorf("Story %d doesn't exist.", storyID)
+	}
+	byteData, _ := json.Marshal(response)
+
+	// Handling get story requests if it isn't comments/reviews.
+	var story Story
+	err := json.Unmarshal(byteData, &story)
+	if err != nil {
+		return nil, err
+	}
+	return &story, nil
 }
 
 // Returns the story using StoryID from the aggregation.

--- a/v5/pivotal/aggregator.go
+++ b/v5/pivotal/aggregator.go
@@ -39,8 +39,7 @@ type Aggregation struct {
 func (a *AggregatorService) GetBuilder() *Aggregation {
 	aggregation := Aggregation{
 		aggregatedResponse: make(map[string]interface{}),
-		// aggregatedData:     make(map[int]*AggregatedStory),
-		service: a,
+		service:            a,
 	}
 	return &aggregation
 }
@@ -136,8 +135,6 @@ func (a *Aggregation) Send() (*Aggregation, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		// a.processAggregationMaps()
 	}
 
 	return a, nil

--- a/v5/pivotal/client.go
+++ b/v5/pivotal/client.go
@@ -57,6 +57,9 @@ type Client struct {
 
 	// Epic Service
 	Epic *EpicService
+
+	// Aggregator Service
+	Aggregator *AggregatorService
 }
 
 // NewClient takes a Pivotal Tracker API Token (created from the project settings) and
@@ -76,6 +79,7 @@ func NewClient(apiToken string) *Client {
 	client.Iterations = newIterationService(client)
 	client.Activity = newActivitiesService(client)
 	client.Epic = newEpicService(client)
+	client.Aggregator = newAggregatorService(client)
 	return client
 }
 


### PR DESCRIPTION
This is one way I thought we could use to decrease the amount of requests we make to PT. It uses the [aggregator](https://www.pivotaltracker.com/help/api#Using_the_GET_Request_Aggregator) to make the GET requests in bulk. 

Below is how it works,
```
	ptClient := pivotal.NewClient("TOKEN")
	ptClient.Aggregator.QueueStoryByID(557367, 181915841)
	ptClient.Aggregator.QueueStoryByID(557367, 182382842)
	ptClient.Aggregator.QueueStoryCommentsByID(557367, 181915841)
	ptClient.Aggregator.QueueStoryCommentsByID(557367, 179601257)
	ptClient.Aggregator.QueueReviewsByID(557367, 179601257)
	ptClient.Aggregator.FinishRequest()

	storyMap, _ := ptClient.Aggregator.GetStoriesFromRequest()
	commentsMap, _ := ptClient.Aggregator.GetStoryCommentsFromRequest()
	reviewsMap, _ := ptClient.Aggregator.GetStoryReviewsFromRequest()
```