### PR TITLE
Adding Accounts Service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,2 @@
+module github.com/oschwald/go-pivotaltracker
+

--- a/go.mod
+++ b/go.mod
@@ -1,2 +1,3 @@
 module github.com/oschwald/go-pivotaltracker
 
+go 1.20

--- a/v5/pivotal/account.go
+++ b/v5/pivotal/account.go
@@ -1,0 +1,41 @@
+package pivotal
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type Account struct {
+	CreatedAt *time.Time `json:"created_at"`
+	ID        int        `json:"id"`
+	Kind      string     `json:"kind"`
+	Name      string     `json:"name"`
+	Plan      string     `json:"plan"`
+	Status    string     `json:"status"`
+	UpdatedAt *time.Time `json:"updated_at"`
+}
+
+type AccountsService struct {
+	client *Client
+}
+
+func newAccountsService(client *Client) *AccountsService {
+	return &AccountsService{client}
+}
+
+func (service *AccountsService) Get(accountID int) (*Account, *http.Response, error) {
+	u := fmt.Sprintf("accounts/%d", accountID)
+	req, err := service.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var account Account
+	resp, err := service.client.Do(req, &account)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &account, resp, nil
+}

--- a/v5/pivotal/client.go
+++ b/v5/pivotal/client.go
@@ -37,6 +37,9 @@ type Client struct {
 	// User-Agent header to use when connecting to the Pivotal Tracker API.
 	userAgent string
 
+	// Accounts service
+	Accounts *AccountsService
+
 	// Me service
 	Me *MeService
 
@@ -72,6 +75,7 @@ func NewClient(apiToken string) *Client {
 		baseURL:   baseURL,
 		userAgent: defaultUserAgent,
 	}
+	client.Accounts = newAccountsService(client)
 	client.Me = newMeService(client)
 	client.Projects = newProjectService(client)
 	client.Stories = newStoryService(client)

--- a/v5/pivotal/me.go
+++ b/v5/pivotal/me.go
@@ -9,21 +9,40 @@ import (
 	"time"
 )
 
+// MeProject represents the fields of the projects returned by the MeService.
+// These are the only fields returned by the MeService unlike
+// the Project service.
+type MeProject struct {
+	Kind         string     `json:"kind"`
+	ID           int        `json:"id"`
+	ProjectID    int        `json:"project_id"`
+	ProjectName  string     `json:"project_name"`
+	ProjectColor string     `json:"project_color"`
+	Favorite     bool       `json:"favorite"`
+	Role         string     `json:"owner"`
+	LastViewedAt *time.Time `json:"last_viewed_at"`
+}
+
 // Me is the primary data object for the MeService.
 type Me struct {
-	ID                         int        `json:"id"`
-	Name                       string     `json:"name"`
-	Initials                   string     `json:"initials"`
-	Username                   string     `json:"username"`
-	TimeZone                   *TimeZone  `json:"time_zone"`
-	APIToken                   string     `json:"api_token"`
-	HasGoogleIdentity          bool       `json:"has_google_identity"`
-	ProjectIDs                 *[]int     `json:"project_ids"`
-	WorkspaceIDs               *[]int     `json:"workspace_ids"`
-	Email                      string     `json:"email"`
-	ReceivedInAppNotifications bool       `json:"receives_in_app_notifications"`
-	CreatedAt                  *time.Time `json:"created_at"`
-	UpdatedAt                  *time.Time `json:"updated_at"`
+	ID                int       `json:"id"`
+	Name              string    `json:"name"`
+	Initials          string    `json:"initials"`
+	Username          string    `json:"username"`
+	TimeZone          *TimeZone `json:"time_zone"`
+	APIToken          string    `json:"api_token"`
+	HasGoogleIdentity bool      `json:"has_google_identity"`
+
+	// TODO: The ProjectIDs field needs to be requested explicitly using
+	// the fields query parameter. It is never populated unlike Projects,
+	// which is populated by default.
+	ProjectIDs                 *[]int       `json:"project_ids"`
+	Projects                   *[]MeProject `json:"projects"`
+	WorkspaceIDs               *[]int       `json:"workspace_ids"`
+	Email                      string       `json:"email"`
+	ReceivedInAppNotifications bool         `json:"receives_in_app_notifications"`
+	CreatedAt                  *time.Time   `json:"created_at"`
+	UpdatedAt                  *time.Time   `json:"updated_at"`
 }
 
 // MeService wraps the client context for interacting with the Me logic.

--- a/v5/pivotal/stories.go
+++ b/v5/pivotal/stories.go
@@ -218,10 +218,9 @@ func newStoriesRequestFunc(client *Client, projectID int, filter string, fields 
 		u := fmt.Sprintf("projects/%v/stories", projectID)
 		if filter != "" {
 			u += "?filter=" + url.QueryEscape(filter)
-			if len(fields) == 0 {
-				fields = DefaultFields
+			if len(fields) != 0 {
+				u += "&fields=" + url.QueryEscape(fieldsToQuery(fields))
 			}
-			u += "&fields=" + url.QueryEscape(fieldsToQuery(fields))
 		}
 		req, _ := client.NewRequest("GET", u, nil)
 		return req


### PR DESCRIPTION
- Added Accounts service
- StoriesService can support the `&fields` parameter. This change lets  us get the `requested_by` field.
- Added a `go.mod`. This makes it easier for forks to replace the original when working on the work. Otherwise, it throws an error. Ex. `replace github.com/oschwald/go-pivotaltracker => Path-to-forked/go-pivotaltracker`